### PR TITLE
Secure photo API and redirect on auth failure

### DIFF
--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -7,6 +7,11 @@ import { createHash } from "node:crypto";
 
 // GET: คืนรูปเป็น URL ของ Cloudinary + width/height
 export async function GET(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id && !session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const url = new URL(req.url);
     const cursor = url.searchParams.get("cursor") ?? undefined;
@@ -16,7 +21,15 @@ export async function GET(req: Request) {
       // แนะนำใส่ secondary orderBy ด้วย id ให้ pagination เสถียร
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: take + 1,
-      where: { url: { not: null } },            // ✅ ใช้ not:null
+      where: {
+        url: { not: null },
+        OR: [
+          ...(session.user?.id ? [{ userId: session.user.id }] : []),
+          ...(session.user?.email
+            ? [{ user: { email: session.user.email } }]
+            : []),
+        ],
+      },
       ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
       select: {
         id: true,

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 interface Photo {
   id: string;
@@ -12,23 +13,28 @@ interface Photo {
 }
 
 export default function GalleryPage() {
+  const router = useRouter();
   const [photos, setPhotos] = useState<Photo[]>([]);
 
-useEffect(() => {
-  (async () => {
-    try {
-      const res = await fetch("/api/photos");
-      if (!res.ok) {
-        const text = await res.text(); 
-        throw new Error(`GET /api/photos ${res.status}: ${text}`);
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/photos');
+        if (res.status === 401) {
+          router.push('/auth/login');
+          return;
+        }
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(`GET /api/photos ${res.status}: ${text}`);
+        }
+        const data: { photos: Photo[]; nextCursor?: string } = await res.json();
+        setPhotos(data.photos);
+      } catch (e) {
+        console.error(e);
       }
-      const data: { photos: Photo[]; nextCursor?: string } = await res.json();
-      setPhotos(data.photos);
-    } catch (e) {
-      console.error(e);
-    }
-  })();
-}, []);
+    })();
+  }, [router]);
 
 
   return (


### PR DESCRIPTION
## Summary
- require a valid session before fetching photos and filter results by current user
- redirect to `/auth/login` when the gallery fetch receives 401

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68b315f1697483259194270f0ad23ad0