### PR TITLE
Add sign out link to homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,33 @@
-
+"use client";
 
 import Link from "next/link";
+import { signOut, useSession } from "next-auth/react";
 
 export default function Home() {
+  const { data: session } = useSession();
+
   return (
     <main className="p-8 space-y-4">
       <h1 className="text-2xl font-bold">Photobooth Demo</h1>
       <div className="space-x-4">
-        <Link href="/photobooth" className="underline">Photobooth</Link>
-        <Link href="/gallery" className="underline">Gallery</Link>
-        <Link href="/auth/login" className="underline">Login</Link>
+        <Link href="/photobooth" className="underline">
+          Photobooth
+        </Link>
+        <Link href="/gallery" className="underline">
+          Gallery
+        </Link>
+        {session ? (
+          <button
+            className="underline"
+            onClick={() => signOut({ callbackUrl: "/auth/login" })}
+          >
+            Sign Out
+          </button>
+        ) : (
+          <Link href="/auth/login" className="underline">
+            Login
+          </Link>
+        )}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- add Sign Out button on homepage when session is active
- redirect to login after signing out

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals")*

------
https://chatgpt.com/codex/tasks/task_e_68b315f26db88325b45117bc55fab79f