### PR TITLE
Stop camera stream after capture

### DIFF
--- a/src/components/Photobooth.tsx
+++ b/src/components/Photobooth.tsx
@@ -22,6 +22,10 @@ export default function Photobooth() {
     if (videoRef.current && stream) {
       videoRef.current.srcObject = stream;
     }
+    return () => {
+      stream?.getTracks().forEach((track) => track.stop());
+      setStream(null);
+    };
   }, [stream]);
 
   const capture = () => {
@@ -37,6 +41,8 @@ export default function Photobooth() {
     ctx.drawImage(video, -canvas.width / 2, -canvas.height / 2);
     ctx.restore();
     drawWithWatermark(ctx);
+    stream?.getTracks().forEach((track) => track.stop());
+    setStream(null);
     setCaptured(true);
   };
 


### PR DESCRIPTION
## Summary
- stop video stream on capture
- clean up video stream when effect unmounts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals")*

------
https://chatgpt.com/codex/tasks/task_e_68b315f315c88325ada3a291856e656e